### PR TITLE
Fixed a bug in the minLong calculation

### DIFF
--- a/src/main/scala/com/cloudera/sa/examples/tablestats/model/ColumnStats.scala
+++ b/src/main/scala/com/cloudera/sa/examples/tablestats/model/ColumnStats.scala
@@ -44,7 +44,7 @@ class ColumnStats(var nulls:Long = 0l,
     empties += columnStats.empties
     sumLong += columnStats.sumLong
     maxLong = maxLong.max(columnStats.maxLong)
-    minLong = minLong.max(columnStats.minLong)
+    minLong = minLong.min(columnStats.minLong)
 
     columnStats.topNValues.topNCountsForColumnArray.foreach{ r =>
       topNValues.add(r._1, r._2)


### PR DESCRIPTION
The min long calculation originally would take the max of the min values instead of the min